### PR TITLE
Fix build on 32-bit platforms with time64 kernels

### DIFF
--- a/lib/core.c
+++ b/lib/core.c
@@ -941,7 +941,8 @@ try_again:
 	}
 
 	memset(ev, 0, sizeof(*ev));
-	memcpy(&ev->time, &input.time, sizeof(struct timeval));
+	memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+	memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 	ev->type = XWII_EVENT_KEY;
 	ev->v.key.code = key;
 	ev->v.key.state = input.value;
@@ -971,7 +972,8 @@ try_again:
 
 	if (input.type == EV_SYN) {
 		memset(ev, 0, sizeof(*ev));
-		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+		memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 		memcpy(ev->v.abs, &dev->accel_cache, sizeof(dev->accel_cache));
 		ev->type = XWII_EVENT_ACCEL;
 		return 0;
@@ -1013,7 +1015,8 @@ try_again:
 
 	if (input.type == EV_SYN) {
 		memset(ev, 0, sizeof(*ev));
-		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+		memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 		memcpy(&ev->v.abs, dev->ir_cache, sizeof(dev->ir_cache));
 		ev->type = XWII_EVENT_IR;
 		return 0;
@@ -1065,7 +1068,8 @@ try_again:
 
 	if (input.type == EV_SYN) {
 		memset(ev, 0, sizeof(*ev));
-		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+		memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 
 		ev->v.abs[0].x = dev->mp_cache.x - dev->mp_normalizer.x / 100;
 		ev->v.abs[0].y = dev->mp_cache.y - dev->mp_normalizer.y / 100;
@@ -1132,7 +1136,8 @@ try_again:
 		}
 
 		memset(ev, 0, sizeof(*ev));
-		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+		memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 		ev->type = XWII_EVENT_NUNCHUK_KEY;
 		ev->v.key.code = key;
 		ev->v.key.state = input.value;
@@ -1150,7 +1155,8 @@ try_again:
 			dev->nunchuk_cache[1].z = input.value;
 	} else if (input.type == EV_SYN) {
 		memset(ev, 0, sizeof(*ev));
-		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+		memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 		memcpy(&ev->v.abs, dev->nunchuk_cache,
 		       sizeof(dev->nunchuk_cache));
 		ev->type = XWII_EVENT_NUNCHUK_MOVE;
@@ -1238,7 +1244,8 @@ try_again:
 		}
 
 		memset(ev, 0, sizeof(*ev));
-		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+		memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 		ev->type = XWII_EVENT_CLASSIC_CONTROLLER_KEY;
 		ev->v.key.code = key;
 		ev->v.key.state = input.value;
@@ -1258,7 +1265,8 @@ try_again:
 			dev->classic_cache[2].x = input.value;
 	} else if (input.type == EV_SYN) {
 		memset(ev, 0, sizeof(*ev));
-		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+		memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 		memcpy(&ev->v.abs, dev->classic_cache,
 		       sizeof(dev->classic_cache));
 		ev->type = XWII_EVENT_CLASSIC_CONTROLLER_MOVE;
@@ -1292,7 +1300,8 @@ try_again:
 
 	if (input.type == EV_SYN) {
 		memset(ev, 0, sizeof(*ev));
-		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+		memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 		memcpy(&ev->v.abs, dev->bboard_cache,
 		       sizeof(dev->bboard_cache));
 		ev->type = XWII_EVENT_BALANCE_BOARD;
@@ -1421,7 +1430,8 @@ try_again:
 		}
 
 		memset(ev, 0, sizeof(*ev));
-		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+		memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 		ev->type = XWII_EVENT_PRO_CONTROLLER_KEY;
 		ev->v.key.code = key;
 		ev->v.key.state = input.value;
@@ -1437,7 +1447,8 @@ try_again:
 			dev->pro_cache[1].y = input.value;
 	} else if (input.type == EV_SYN) {
 		memset(ev, 0, sizeof(*ev));
-		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+		memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 		memcpy(&ev->v.abs, dev->pro_cache,
 		       sizeof(dev->pro_cache));
 		ev->type = XWII_EVENT_PRO_CONTROLLER_MOVE;
@@ -1486,7 +1497,8 @@ try_again:
 		}
 
 		memset(ev, 0, sizeof(*ev));
-		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+		memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 		ev->type = XWII_EVENT_DRUMS_KEY;
 		ev->v.key.code = key;
 		ev->v.key.state = input.value;
@@ -1533,7 +1545,8 @@ try_again:
 			dev->drums_cache[XWII_DRUMS_ABS_HI_HAT].x = input.value;
 	} else if (input.type == EV_SYN) {
 		memset(ev, 0, sizeof(*ev));
-		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+		memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 		memcpy(&ev->v.abs, dev->drums_cache,
 		       sizeof(dev->drums_cache));
 		ev->type = XWII_EVENT_DRUMS_MOVE;
@@ -1623,7 +1636,8 @@ try_again:
 		}
 
 		memset(ev, 0, sizeof(*ev));
-		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+		memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 		ev->type = XWII_EVENT_GUITAR_KEY;
 		ev->v.key.code = key;
 		ev->v.key.state = input.value;
@@ -1645,7 +1659,8 @@ try_again:
 			dev->guitar_cache[2].x = input.value;
 	} else if (input.type == EV_SYN) {
 		memset(ev, 0, sizeof(*ev));
-		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		memcpy(&ev->time.tv_sec, &input.input_event_sec, sizeof(struct timeval));
+		memcpy(&ev->time.tv_usec, &input.input_event_usec, sizeof(struct timeval));
 		memcpy(&ev->v.abs, dev->guitar_cache,
 		       sizeof(dev->guitar_cache));
 		ev->type = XWII_EVENT_GUITAR_MOVE;


### PR DESCRIPTION
On 32-bit arches input_event->time is undefined when using a time64
kernel. Instead read the input_event_sec and input_event_usec values
directly and save those instead