### PR TITLE
Initialize ir_cache to invalid values

### DIFF
--- a/lib/core.c
+++ b/lib/core.c
@@ -345,6 +345,8 @@ int xwii_iface_new(struct xwii_iface **dev, const char *syspath)
 	d->ref = 1;
 	d->rumble_id = -1;
 	d->rumble_fd = -1;
+	for (int i = 0; i < 4; ++i)
+		d->ir_cache[i] = (struct xwii_event_abs){.x = 1023, .y = 1023};
 
 	for (i = 0; i < XWII_IF_NUM; ++i)
 		d->ifs[i].fd = -1;


### PR DESCRIPTION
Write 1023 to `ir_cache` coordinate fields on device creation so that `xwii_event_ir_is_valid` works correctly. Fixes #88.